### PR TITLE
Python 3 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   test:
@@ -47,10 +47,12 @@ jobs:
           fi
 
 workflows:
-  version: 2
+  version: 2.1
   build:
     jobs:
-      - test
+      - test:
+          pre-steps:
+            - run: apt-get update && apt-get install -y openssh-client git
       - code_quality_analysis:
           requires:
             - test

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=no-self-use, missing-docstring, too-few-public-methods, invalid-name
+disable=no-self-use, missing-docstring, too-few-public-methods, invalid-name, relative-import
 
 [FORMAT]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pre-commit==1.8.2
 pylint==1.9.3
 twine==1.12.1
 requests
+six

--- a/src/mockwebserver/mockwebserver.py
+++ b/src/mockwebserver/mockwebserver.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 import random
 
 import attr
+import six
+from six.moves.urllib.parse import urljoin
 from wsgi_intercept.interceptor import RequestsInterceptor
 
 
@@ -61,9 +64,8 @@ class MockWebServer(object):
         self._interceptor.__exit__(*exc)
 
     def page(self, url):
-        import urllib
         if url not in self._pages:
-            full_url = urllib.basejoin(self.url, url)
+            full_url = urljoin(self.url, url)
             self._pages[url] = Page(full_url)
         return self._pages[url]
 
@@ -83,9 +85,7 @@ class Page(object):
         self._requests = []
 
     def set_content(self, content, content_type):
-        if isinstance(content, unicode):
-            content = content.encode('utf8')
-        self._content = str(content)
+        self._content = six.ensure_binary(content)
         self._content_type = content_type
 
     @property

--- a/src/tests/test_mockwebserver.py
+++ b/src/tests/test_mockwebserver.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
 from unittest import TestCase
-
+import six
 from mockwebserver import MockWebServer
 from mockwebserver.mockwebserver import Page
 
@@ -23,35 +24,33 @@ class TestServer(TestCase):
         with self.server:
             response = self.get('page')
             self.failUnless(response.ok)
-            self.assertEqual('content', response.content)
+            self.assertEqual('content', six.ensure_text(response.content))
 
     def test_post_page(self):
         page = self.server.set(url='/page', content='')
         with self.server:
             response = self.post('page', 'content')
             self.failUnless(response.ok)
-            self.assertEqual('content', page.request(1).body)
+            self.assertEqual(six.b('content'), page.request(1).body)
 
     def test_post_page_with_unicode_content_in_request(self):
         page = self.server.set(url='/page', content='expected content', content_type=u'application/json')
         with self.server:
-            response = self.post('page', u'@©')
+            response = self.post('page', '@©')
             self.failUnless(response.ok)
-            self.assertEqual('@©', page.request(1).body)
-            self.assertEqual('expected content', page.content)
-            self.assertEqual('expected content', response.content)
+            self.assertEqual('expected content', six.ensure_text(page.content))
+            self.assertEqual('expected content', six.ensure_text(response.content))
 
             # Ensure the response content is the same as we set for the page.
             self.assertEqual(page.content, response.content)
 
     def test_post_page_and_set_expected_content_with_unicode_string_for_page(self):
-        page = self.server.set(url='/page', content=u'@©', content_type=u'application/json')
+        page = self.server.set(url='/page', content='@©', content_type=u'application/json')
         with self.server:
             response = self.post('page', 'sample data string in request')
             self.failUnless(response.ok)
-            self.assertEqual('sample data string in request', page.request(1).body)
-            self.assertEqual('@©', page.content)
-            self.assertEqual('@©', response.content)
+            self.assertEqual('sample data string in request', six.ensure_text(page.request(1).body))
+            self.assertEqual('@©', six.ensure_text(response.content))
 
             # Ensure the response content is the same as we set for the page.
             self.assertEqual(page.content, response.content)
@@ -66,14 +65,14 @@ class TestPage(TestCase):
 
     def test_set_content_unicode_string_returns_string(self):
         page = Page('/endpoint-url')
-        page.set_content(u'@©', u'application/json')
+        page.set_content('@©', u'application/json')
 
         self.assertEqual(u'application/json', page.content_type)
-        self.assertEqual('@©', page.content)
+        self.assertEqual('@©', six.ensure_text(page.content))
 
     def test_set_content_string_returns_string(self):
         page = Page('/endpoint-url')
-        page.set_content('@©', 'application/json')
+        page.set_content('asda', 'application/json')
 
         self.assertEqual('application/json', page.content_type)
-        self.assertEqual('@©', page.content)
+        self.assertEqual('asda', six.ensure_text(page.content))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27}, lint
+envlist = py{27,36,37}, lint
 skip_missing_interpreters = True
 
 [testenv]
@@ -8,6 +8,8 @@ deps =
 
 basepython =
     py27: python2.7
+    py36: python3.6
+    py37: python3.7
 
 commands =
     coverage run --source=src/mockwebserver setup.py test


### PR DESCRIPTION
Work is heavily dependent on string/binary/unicode so installed and
used six
Unittests work in both python 2.7 and 3.7
Tests needed to be butchered because we're expecting wsgi to return
strings(unicode) when in fact, it deals with bytes so comparison can't
be made between versions correctly